### PR TITLE
Discard old packets

### DIFF
--- a/src/NTPClient_Generic.h
+++ b/src/NTPClient_Generic.h
@@ -77,6 +77,7 @@ class NTPClient
 
     void          sendNTPPacket();
     bool          checkResponse();
+    void          discardPendingData();
 
   public:
     NTPClient(UDP& udp, long timeOffset = 0);

--- a/src/NTPClient_Generic_Impl.h
+++ b/src/NTPClient_Generic_Impl.h
@@ -121,14 +121,22 @@ bool NTPClient::checkResponse()
   return false;
 }
 
+void NTPClient::discardPendingData()
+{
+
+  while (this->_udp->parsePacket() != 0)
+  {
+    //this->_udp->flush(); // not implemented
+    byte temp[NTP_PACKET_SIZE];
+    this->_udp->read(temp, sizeof temp);
+  }
+}
+
 bool NTPClient::forceUpdate()
 {
   NTP_LOGDEBUG("Update from NTP Server");
 
-  // flush any existing packets
-  while (this->_udp->parsePacket() != 0)
-    this->_udp->flush();
-
+  this->discardPendingData();
   this->sendNTPPacket();
 
   // Wait till data is there or timeout...
@@ -164,10 +172,7 @@ bool NTPClient::update()
       this->begin();
     }
 
-    // flush any existing packets
-    while (this->_udp->parsePacket() != 0)
-      this->_udp->flush();
-
+    this->discardPendingData();
     this->sendNTPPacket();
   }
 

--- a/src/NTPClient_Generic_Impl.h
+++ b/src/NTPClient_Generic_Impl.h
@@ -164,6 +164,10 @@ bool NTPClient::update()
       this->begin();
     }
 
+    // flush any existing packets
+    while (this->_udp->parsePacket() != 0)
+      this->_udp->flush();
+
     this->sendNTPPacket();
   }
 

--- a/src_cpp/NTPClient_Generic.cpp
+++ b/src_cpp/NTPClient_Generic.cpp
@@ -121,14 +121,22 @@ bool NTPClient::checkResponse()
   return false;
 }
 
+void NTPClient::discardPendingData()
+{
+
+  while (this->_udp->parsePacket() != 0)
+  {
+    //this->_udp->flush(); // not implemented
+    byte temp[NTP_PACKET_SIZE];
+    this->_udp->read(temp, sizeof temp);
+  }
+}
+
 bool NTPClient::forceUpdate()
 {
   NTP_LOGDEBUG("Update from NTP Server");
 
-  // flush any existing packets
-  while (this->_udp->parsePacket() != 0)
-    this->_udp->flush();
-
+  this->discardPendingData();
   this->sendNTPPacket();
 
   // Wait till data is there or timeout...
@@ -164,10 +172,7 @@ bool NTPClient::update()
       this->begin();
     }
 
-    // flush any existing packets
-    while (this->_udp->parsePacket() != 0)
-      this->_udp->flush();
-
+    this->discardPendingData();
     this->sendNTPPacket();
   }
 

--- a/src_cpp/NTPClient_Generic.cpp
+++ b/src_cpp/NTPClient_Generic.cpp
@@ -164,6 +164,10 @@ bool NTPClient::update()
       this->begin();
     }
 
+    // flush any existing packets
+    while (this->_udp->parsePacket() != 0)
+      this->_udp->flush();
+
     this->sendNTPPacket();
   }
 

--- a/src_cpp/NTPClient_Generic.h
+++ b/src_cpp/NTPClient_Generic.h
@@ -77,6 +77,7 @@ class NTPClient
 
     void          sendNTPPacket();
     bool          checkResponse();
+    void          discardPendingData();
 
   public:
     NTPClient(UDP& udp, long timeOffset = 0);

--- a/src_h/NTPClient_Generic.h
+++ b/src_h/NTPClient_Generic.h
@@ -77,6 +77,7 @@ class NTPClient
 
     void          sendNTPPacket();
     bool          checkResponse();
+    void          discardPendingData();
 
   public:
     NTPClient(UDP& udp, long timeOffset = 0);

--- a/src_h/NTPClient_Generic_Impl.h
+++ b/src_h/NTPClient_Generic_Impl.h
@@ -121,14 +121,22 @@ bool NTPClient::checkResponse()
   return false;
 }
 
+void NTPClient::discardPendingData()
+{
+
+  while (this->_udp->parsePacket() != 0)
+  {
+    //this->_udp->flush(); // not implemented
+    byte temp[NTP_PACKET_SIZE];
+    this->_udp->read(temp, sizeof temp);
+  }
+}
+
 bool NTPClient::forceUpdate()
 {
   NTP_LOGDEBUG("Update from NTP Server");
 
-  // flush any existing packets
-  while (this->_udp->parsePacket() != 0)
-    this->_udp->flush();
-
+  this->discardPendingData();
   this->sendNTPPacket();
 
   // Wait till data is there or timeout...
@@ -164,10 +172,7 @@ bool NTPClient::update()
       this->begin();
     }
 
-    // flush any existing packets
-    while (this->_udp->parsePacket() != 0)
-      this->_udp->flush();
-
+    this->discardPendingData();
     this->sendNTPPacket();
   }
 

--- a/src_h/NTPClient_Generic_Impl.h
+++ b/src_h/NTPClient_Generic_Impl.h
@@ -164,6 +164,10 @@ bool NTPClient::update()
       this->begin();
     }
 
+    // flush any existing packets
+    while (this->_udp->parsePacket() != 0)
+      this->_udp->flush();
+
     this->sendNTPPacket();
   }
 


### PR DESCRIPTION
This resolves an issue I experienced where some old packets were causing updates to old times.

For instance, suppose an NTP packet from the server is delayed, so `NTPClient::update()` retries before the first arrives. Then the first arrives, time is updated, and the second packet arrives, and remains unparsed. Before this patch, when calling `update()` the next time, it would parse the old out-of-date packet.

The [original NTPClient](https://github.com/arduino-libraries/NTPClient) tries to do this, with its `parsePacket()` / `flush()` loop in its `forceUpdate()` function (which is also used by its `update()` function). It doesn't work though, since `WiFiUDP::parsePacket()` doesn't advance to the next packet without `WiFiUDP::read()`, and `WiFiUDP::flush()` isn't implemented.